### PR TITLE
burninate docker and cleanup old files

### DIFF
--- a/content/blog/2015-10-12-a-tale-of-two-dockers.markdown
+++ b/content/blog/2015-10-12-a-tale-of-two-dockers.markdown
@@ -1,6 +1,6 @@
 Title: A tale of two Dockers
 Date: 2015-10-12 14:14
-Category: Docker 
+Category: Development
 Tags: php, performance
 Authors: Daniel Axtens
 

--- a/content/blog/2015-10-30-docker-just-stop-using-aufs.markdown
+++ b/content/blog/2015-10-30-docker-just-stop-using-aufs.markdown
@@ -2,7 +2,7 @@ Title: Docker: Just Stop Using AUFS
 Date: 2015-10-30 13:30
 Authors: Daniel Axtens
 Tags: aufs, overlay, performance
-Category: Docker
+Category: Performance
 
 Docker's default storage driver on most Ubuntu installs is AUFS.
 

--- a/content/blog/2016-07-27-get-off-my-lawn.markdown
+++ b/content/blog/2016-07-27-get-off-my-lawn.markdown
@@ -1,7 +1,7 @@
 Title: Get off my lawn: separating Docker workloads using cgroups
 Date: 2016-07-27 13:30
 Authors: Daniel Axtens
-Category: Docker
+Category: Performance
 Tags: cgroups, numa, p8
 
 On my team, we do two different things in our Continuous Integration setup: build/functional tests, and performance tests. Build tests simply test whether a project builds, and, if the project provides a functional test suite, that the tests pass. We do a lot of MySQL/MariaDB testing this way. The other type of testing we do is performance tests: we build a project and then run a set of benchmarks against it. Python is a good example here.


### PR DESCRIPTION
The top menubar is getting crowded. Do away with the Docker category; it only had my posts and they live just as well or better in other categories.

Also clean up some files that were created a long time ago and got committed despite no longer matching any content.