### PR TITLE
Add automatic dependency installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .\#*
 *~
 output/
+venv


### PR DESCRIPTION
We only need Python packages and a submodule, so automatically create a local virtual environment and use it in commands.